### PR TITLE
feat: distribute rewards to executor

### DIFF
--- a/contracts/oraiswap_limit_order/src/order.rs
+++ b/contracts/oraiswap_limit_order/src/order.rs
@@ -178,7 +178,7 @@ pub fn excecute_pair(
     let mut ret_attributes: Vec<Vec<Attribute>> = vec![];
     let mut total_orders =  0;
 
-    let mut reward_amount ;
+    let mut reward_amount;
 
     for buy_order in &mut match_buy_orders {
         buy_order.status = OrderStatus::Filling;
@@ -186,6 +186,7 @@ pub fn excecute_pair(
 
         let bidder_addr = deps.api.addr_humanize(&buy_order.bidder_addr)?;
         let mut match_price = buy_order.get_price();
+        let mut sell_ask_amount = Uint128::zero();
 
         for sell_order in &mut match_sell_orders {
             // check status of sell_order and buy_order
@@ -248,7 +249,7 @@ pub fn excecute_pair(
 
                 sell_order.status = OrderStatus::Open;
                 store_order(deps.storage, &pair_key, &sell_order, false)?;
-                continue;                
+                continue;
             }
 
             if lef_sell_ask_amount.is_zero() || sell_offer_amount.is_zero() {
@@ -281,6 +282,7 @@ pub fn excecute_pair(
             sell_order.fill_order(deps.storage, &pair_key, sell_ask_asset.amount, sell_offer_amount)?;
 
             if !sell_ask_asset.amount.is_zero() {
+                sell_ask_amount = sell_ask_asset.amount;
                 reward_amount = sell_ask_asset.amount * commission_rate;
                 executor.reward_assets[1].amount += reward_amount;
                 executor.reward_assets[1].info = asset_infos[1].clone();
@@ -313,7 +315,7 @@ pub fn excecute_pair(
                     deps.storage,
                     &pair_key,
                     sell_offer_amount,
-                    sell_ask_asset.amount,
+                    sell_ask_amount,
                 )?;
 
                 let mut buy_ask_asset = Asset {

--- a/contracts/oraiswap_limit_order/src/order.rs
+++ b/contracts/oraiswap_limit_order/src/order.rs
@@ -384,7 +384,7 @@ pub fn distribute_reward(
         let pair_key = pair_key(&[asset_info[0].to_raw(deps.api)?, asset_info[1].to_raw(deps.api)?]);
         let num_executor = read_last_executor_id(deps.storage).unwrap_or_default();
         let list_executor = read_excecutors(deps.storage, &pair_key, None, Some(num_executor), None)?;
-        for executor in list_executor {
+        for mut executor in list_executor {
             reward_assets = [
                 Asset {
                     info: asset_info[0].clone(),
@@ -405,6 +405,9 @@ pub fn distribute_reward(
                 &deps.querier,
                 deps.api.addr_validate(deps.api.addr_humanize(&executor.address)?.as_str())?,
             )?);
+            executor.reward_assets[0].amount = Uint128::zero();
+            executor.reward_assets[1].amount = Uint128::zero();
+            store_executor(deps.storage, &pair_key, &executor)?;
         }
     }
 

--- a/contracts/oraiswap_limit_order/src/orderbook.rs
+++ b/contracts/oraiswap_limit_order/src/orderbook.rs
@@ -29,6 +29,12 @@ pub struct Order {
     pub status: OrderStatus,
 }
 
+#[cw_serde]
+pub struct Executor {
+    pub address: CanonicalAddr,
+    pub reward_assets: [Asset; 2],
+}
+
 impl Order {
     // create new order given a price and an offer amount
     pub fn new(
@@ -318,5 +324,17 @@ impl OrderBook {
             Some(OrderBy::Ascending), // if mean we process from first to last order in the orderlist
         )
         .unwrap_or_default() // default is empty list
+    }
+}
+
+impl Executor {
+    pub fn new(
+        address: CanonicalAddr,
+        reward_assets: [Asset; 2],
+    ) -> Self {
+        Executor {
+            address,
+            reward_assets,
+        }
     }
 }

--- a/contracts/oraiswap_limit_order/src/state.rs
+++ b/contracts/oraiswap_limit_order/src/state.rs
@@ -41,6 +41,18 @@ pub fn read_last_executor_id(storage: &dyn Storage) -> StdResult<u32> {
     singleton_read(storage, KEY_LAST_EXECUTOR).load()
 }
 
+pub fn store_last_distributed(
+    storage: &mut dyn Storage,
+    pair_key: &[u8],
+    last_distributed: u64,
+) -> StdResult<()> {
+    Bucket::new(storage, KEY_LAST_DISTRIBUTED).save(pair_key, &last_distributed)
+}
+
+pub fn read_last_distributed(storage: &dyn Storage, pair_key: &[u8]) -> StdResult<u64> {
+    ReadonlyBucket::new(storage, KEY_LAST_DISTRIBUTED).load(pair_key)
+}
+
 pub fn store_executor(
     storage: &mut dyn Storage,
     pair_key: &[u8],
@@ -273,6 +285,7 @@ static CONTRACT_INFO: &[u8] = b"contract_info"; // contract info
 static PREFIX_ORDER_BOOK: &[u8] = b"order_book"; // store config for an order book like min ask amount and min sell amount
 static PREFIX_ORDER: &[u8] = b"order"; // this is orderbook
 static KEY_LAST_EXECUTOR: &[u8] = b"last_executor"; // store last executor
+static KEY_LAST_DISTRIBUTED: &[u8] = b"last_distributed_to_executor"; // store last distributed to executor
 static PREFIX_EXECUTOR: &[u8] = b"executor"; // executor that running matching engine for orderbook pair
 
 pub static PREFIX_ORDER_BY_BIDDER: &[u8] = b"order_by_bidder"; // order from a bidder

--- a/contracts/oraiswap_limit_order/src/state.rs
+++ b/contracts/oraiswap_limit_order/src/state.rs
@@ -1,9 +1,9 @@
-use cosmwasm_std::{Order as OrderBy, StdResult, Storage};
+use cosmwasm_std::{Order as OrderBy, StdResult, Storage, CanonicalAddr};
 use cosmwasm_storage::{singleton, singleton_read, Bucket, ReadonlyBucket};
-use oraiswap::{limit_order::ContractInfo, querier::calc_range_start};
+use oraiswap::{limit_order::{ContractInfo}, querier::calc_range_start};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::orderbook::{Order, OrderBook};
+use crate::orderbook::{Order, OrderBook, Executor};
 
 // settings for pagination
 pub const MAX_LIMIT: u32 = 100;
@@ -27,6 +27,55 @@ pub fn store_config(storage: &mut dyn Storage, config: &ContractInfo) -> StdResu
 
 pub fn read_config(storage: &dyn Storage) -> StdResult<ContractInfo> {
     singleton_read(storage, CONTRACT_INFO).load()
+}
+
+pub fn init_last_executor_id(storage: &mut dyn Storage) -> StdResult<()> {
+    singleton(storage, KEY_LAST_EXECUTOR).save(&0u64)
+}
+
+pub fn increase_last_executor_id(storage: &mut dyn Storage) -> StdResult<u64> {
+    singleton(storage, KEY_LAST_EXECUTOR).update(|v| Ok(v + 1))
+}
+
+pub fn read_last_executor_id(storage: &dyn Storage) -> StdResult<u32> {
+    singleton_read(storage, KEY_LAST_EXECUTOR).load()
+}
+
+pub fn store_executor(
+    storage: &mut dyn Storage,
+    pair_key: &[u8],
+    executor: &Executor
+) -> StdResult<()> {
+    let executor_address_key = &executor.address;
+    Bucket::multilevel(storage, &[PREFIX_EXECUTOR, pair_key]).save(executor_address_key, executor)
+}
+
+pub fn read_excecutor(storage: &dyn Storage, pair_key: &[u8], address: &CanonicalAddr) -> StdResult<Executor> {
+    ReadonlyBucket::multilevel(storage, &[PREFIX_EXECUTOR, pair_key]).load(address)
+}
+
+pub fn read_excecutors(
+    storage: &mut dyn Storage,
+    pair_key: &[u8],
+    start_after: Option<u64>,
+    limit: Option<u32>,
+    order_by: Option<OrderBy>,
+) -> StdResult<Vec<Executor>> {
+    let position_bucket: ReadonlyBucket<Executor> =
+        ReadonlyBucket::multilevel(storage, &[PREFIX_EXECUTOR, pair_key]);
+
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start_after = start_after.map(|id| id.to_be_bytes().to_vec());
+    let (start, end, order_by) = match order_by {
+        Some(OrderBy::Ascending) => (calc_range_start(start_after), None, OrderBy::Ascending),
+        _ => (None, start_after, OrderBy::Descending),
+    };
+
+    position_bucket
+        .range(start.as_deref(), end.as_deref(), order_by)
+        .take(limit)
+        .map(|item| item.map(|item| item.1))
+        .collect()
 }
 
 pub fn store_orderbook(
@@ -223,6 +272,8 @@ static KEY_LAST_ORDER_ID: &[u8] = b"last_order_id"; // should use big int? guess
 static CONTRACT_INFO: &[u8] = b"contract_info"; // contract info
 static PREFIX_ORDER_BOOK: &[u8] = b"order_book"; // store config for an order book like min ask amount and min sell amount
 static PREFIX_ORDER: &[u8] = b"order"; // this is orderbook
+static KEY_LAST_EXECUTOR: &[u8] = b"last_executor"; // store last executor
+static PREFIX_EXECUTOR: &[u8] = b"executor"; // executor that running matching engine for orderbook pair
 
 pub static PREFIX_ORDER_BY_BIDDER: &[u8] = b"order_by_bidder"; // order from a bidder
 pub static PREFIX_ORDER_BY_PRICE: &[u8] = b"order_by_price"; // this where orders belong to tick

--- a/contracts/oraiswap_limit_order/src/testing/contract_test.rs
+++ b/contracts/oraiswap_limit_order/src/testing/contract_test.rs
@@ -55,6 +55,8 @@ fn submit_order() {
         name: None,
         version: None,
         admin: None,
+        commission_rate: None,
+        distribution_interval: None,
     };
     let code_id = app.upload(Box::new(create_entry_points_testing!(crate)));
     let limit_order_addr = app
@@ -537,6 +539,8 @@ fn cancel_order_native_token() {
         name: None,
         version: None,
         admin: None,
+        commission_rate: None,
+        distribution_interval: None,
     };
     let code_id = app.upload(Box::new(create_entry_points_testing!(crate)));
     let limit_order_addr = app
@@ -876,6 +880,8 @@ fn cancel_order_token() {
         name: None,
         version: None,
         admin: None,
+        commission_rate: None,
+        distribution_interval: None,
     };
     let code_id = app.upload(Box::new(create_entry_points_testing!(crate)));
     let limit_order_addr = app
@@ -1182,6 +1188,8 @@ fn execute_pair_native_token() {
         name: None,
         version: None,
         admin: None,
+        commission_rate: None,
+        distribution_interval: None,
     };
     let code_id = app.upload(Box::new(create_entry_points_testing!(crate)));
     let limit_order_addr = app
@@ -2279,7 +2287,7 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(963200u128)
+            amount: Uint128::from(963192u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
@@ -2297,7 +2305,7 @@ fn execute_pair_native_token() {
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(962000u128),
+            amount: Uint128::from(961994u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2336,7 +2344,7 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(966199u128)
+            amount: Uint128::from(966183u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
@@ -2354,7 +2362,7 @@ fn execute_pair_native_token() {
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(964003u128),
+            amount: Uint128::from(963993u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2393,7 +2401,7 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(966199u128)
+            amount: Uint128::from(966183u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
@@ -2407,11 +2415,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(964003u128),
+            amount: Uint128::from(963993u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2450,11 +2458,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980197u128)
+            amount: Uint128::from(980141u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(985614u128),
+            amount: Uint128::from(985572u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2464,11 +2472,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(964003u128),
+            amount: Uint128::from(963993u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2507,11 +2515,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980198u128)
+            amount: Uint128::from(980142u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(985615u128),
+            amount: Uint128::from(985573u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2521,11 +2529,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(964003u128),
+            amount: Uint128::from(963993u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2564,11 +2572,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980199u128)
+            amount: Uint128::from(980142u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(985615u128),
+            amount: Uint128::from(985573u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2578,11 +2586,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(964003u128),
+            amount: Uint128::from(963993u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2621,11 +2629,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980990u128)
+            amount: Uint128::from(980931u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(985615u128),
+            amount: Uint128::from(985573u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2635,11 +2643,11 @@ fn execute_pair_native_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         },
         Coin{
             denom: USDT_DENOM.to_string(),
-            amount: Uint128::from(965585u128),
+            amount: Uint128::from(965571u128),
         }
     ].to_vec();
     assert_eq!(
@@ -2660,6 +2668,28 @@ fn execute_pair_native_token() {
         address2_balances,
         expected_balances,
     );
+    
+    // Distribute to the executor
+    let msg = ExecuteMsg::DistributeReward {
+        asset_infos: [
+            [
+                AssetInfo::NativeToken {
+                    denom: ORAI_DENOM.to_string(),
+                },
+                AssetInfo::NativeToken {
+                    denom: USDT_DENOM.to_string(),
+                },
+            ],
+        ].into()
+    };
+
+    let res = app.execute(
+        Addr::unchecked("addr0000"),
+        limit_order_addr.clone(),
+        &msg,
+        &[],
+    );
+    println!("distribute rewards res: {:?}", res);
 }
 
 #[test]
@@ -2711,6 +2741,8 @@ fn execute_pair_cw20_token() {
         name: None,
         version: None,
         admin: None,
+        commission_rate: None,
+        distribution_interval: None,
     };
     let code_id = app.upload(Box::new(create_entry_points_testing!(crate)));
     let limit_order_addr = app
@@ -3830,7 +3862,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(963200u128)
+            amount: Uint128::from(963192u128)
         }
     ].to_vec();
     assert_eq!(
@@ -3875,7 +3907,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(966199u128)
+            amount: Uint128::from(966183u128)
         }
     ].to_vec();
     assert_eq!(
@@ -3920,7 +3952,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(966199u128)
+            amount: Uint128::from(966183u128)
         }
     ].to_vec();
     assert_eq!(
@@ -3930,7 +3962,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         }
     ].to_vec();
     assert_eq!(
@@ -3965,7 +3997,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980197u128)
+            amount: Uint128::from(980141u128)
         }
     ].to_vec();
     assert_eq!(
@@ -3975,7 +4007,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         }
     ].to_vec();
     assert_eq!(
@@ -4010,7 +4042,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980198u128)
+            amount: Uint128::from(980142u128)
         }
     ].to_vec();
     assert_eq!(
@@ -4020,7 +4052,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         }
     ].to_vec();
     assert_eq!(
@@ -4055,7 +4087,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980199u128)
+            amount: Uint128::from(980142u128)
         }
     ].to_vec();
     assert_eq!(
@@ -4065,7 +4097,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         }
     ].to_vec();
     assert_eq!(
@@ -4100,7 +4132,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(980990u128)
+            amount: Uint128::from(980931u128)
         }
     ].to_vec();
     assert_eq!(
@@ -4110,7 +4142,7 @@ fn execute_pair_cw20_token() {
     expected_balances = [
         Coin{
             denom: ORAI_DENOM.to_string(),
-            amount: Uint128::from(973801u128)
+            amount: Uint128::from(973800u128)
         }
     ].to_vec();
     assert_eq!(
@@ -4127,6 +4159,28 @@ fn execute_pair_cw20_token() {
         address2_balances,
         expected_balances,
     );
+
+    // Distribute to the executor
+    let msg = ExecuteMsg::DistributeReward {
+        asset_infos: [
+            [
+                AssetInfo::NativeToken {
+                    denom: ORAI_DENOM.to_string(),
+                },
+                AssetInfo::Token {
+                    contract_addr: token_addrs[0].clone(),
+                },
+            ],
+        ].into()
+    };
+
+    let res = app.execute(
+        Addr::unchecked("addr0000"),
+        limit_order_addr.clone(),
+        &msg,
+        &[],
+    );
+    println!("distribute rewards res: {:?}", res);
 }
 
 #[test]
@@ -4177,6 +4231,8 @@ fn remove_orderbook_pair() {
         name: None,
         version: None,
         admin: None,
+        commission_rate: None,
+        distribution_interval: None,
     };
 
     let code_id = app.upload(Box::new(create_entry_points_testing!(crate)));
@@ -4440,6 +4496,8 @@ fn orders_querier() {
         name: None,
         version: None,
         admin: None,
+        commission_rate: None,
+        distribution_interval: None,
     };
     let code_id = app.upload(Box::new(create_entry_points_testing!(crate)));
     let limit_order_addr = app

--- a/packages/oraiswap/src/limit_order.rs
+++ b/packages/oraiswap/src/limit_order.rs
@@ -9,6 +9,9 @@ pub struct ContractInfo {
     pub version: String,
     // admin can update the parameter, may be multisig
     pub admin: CanonicalAddr,
+    pub init_time: u64,
+    pub commission_rate: String,
+    pub distribution_interval: u64,
 }
 
 #[cw_serde]
@@ -59,6 +62,8 @@ pub struct InstantiateMsg {
     pub name: Option<String>,
     pub version: Option<String>,
     pub admin: Option<Addr>,
+    pub commission_rate: Option<String>,
+    pub distribution_interval: Option<u64>,
 }
 
 #[cw_serde]
@@ -92,6 +97,11 @@ pub enum ExecuteMsg {
     /// Arbitrager execute order book pair
     ExecuteOrderBookPair {
         asset_infos: [AssetInfo; 2],
+    },
+
+    /// Distribute reward to executor who run the matching engine
+    DistributeReward {
+        asset_infos: Vec<[AssetInfo; 2]>,
     },
 
     /// Arbitrager remove order book


### PR DESCRIPTION
**What is the purpose of the change**

- Distribute reward to executor
- Add unit-test

**Brief Changelog**

- Each successfully matched order, the executor will receive **0.3%** of matching amount
- Contract's admin will distribute rewards to all executor every **600** seconds

**Documentation and Release Note**

- Does this pull request introduces a new feature or user-facing behaviour changes? yes
- How is the feature or change documented? no